### PR TITLE
< :technologist: :building_construction: >[color-u8] switch color to [f32; 4] from u8 struct

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Test
         run: cargo test --workspace
+      - name: Dry-run vmnl_native publish
+        run: cargo publish -p vmnl_native --dry-run
       - name: Publish vmnl_native
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -p vmnl_native
+      - name: Wait for crates.io index
+        run: sleep 60
+      - name: Dry-run vmnl publish
+        run: cargo publish -p vmnl --dry-run
       - name: Publish vmnl
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,72 +3,10 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
-
-[[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
-dependencies = [
- "stable_deref_trait",
-]
 
 [[package]]
 name = "ash"
@@ -78,61 +16,6 @@ checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
  "libloading",
 ]
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror",
- "v_frame",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom 8.0.0",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "bit_field"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -145,27 +28,6 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
-name = "bitstream-io"
-version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
-dependencies = [
- "core2",
-]
-
-[[package]]
-name = "built"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
-
-[[package]]
-name = "bumpalo"
-version = "3.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -188,20 +50,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
-
-[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -218,49 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -295,32 +106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,64 +122,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "exr"
-version = "1.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
-dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
-name = "fax"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "foldhash"
@@ -413,28 +144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
-
-[[package]]
-name = "gif"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "glfw"
 version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,8 +151,6 @@ checksum = "61c38183b2df227d4b59fcabc647ccc65d04ed9a14420ea9c1520e5ed09b6a79"
 dependencies = [
  "bitflags 1.3.2",
  "glfw-sys",
- "image",
- "log",
  "objc2 0.5.2",
  "raw-window-handle",
  "winapi",
@@ -484,46 +191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "image"
-version = "0.25.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "color_quant",
- "exr",
- "gif",
- "image-webp",
- "moxcms",
- "num-traits",
- "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
- "tiff",
- "zune-core 0.5.1",
- "zune-jpeg 0.5.12",
-]
-
-[[package]]
-name = "image-webp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
-dependencies = [
- "byteorder-lite",
- "quick-error",
-]
-
-[[package]]
-name = "imgref"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
-
-[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,62 +201,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom",
- "libc",
-]
-
-[[package]]
-name = "lebe"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
-
-[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
-dependencies = [
- "arbitrary",
- "cc",
-]
 
 [[package]]
 name = "libloading"
@@ -623,25 +244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,32 +256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
-name = "moxcms"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,71 +263,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -861,44 +372,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.11.0",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -919,137 +396,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "profiling"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pxfm"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rav1e"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
-dependencies = [
- "aligned-vec",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av-scenechange",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand",
- "rand_chacha",
- "simd_helpers",
- "thiserror",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rayon",
- "rgb",
 ]
 
 [[package]]
@@ -1071,26 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,12 +430,6 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
 ]
-
-[[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "roxmltree"
@@ -1126,12 +452,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scopeguard"
@@ -1210,21 +530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
-
-[[package]]
 name = "slabbin"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,12 +540,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
@@ -1261,46 +560,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tiff"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -1340,17 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "v_frame"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "vk-parse"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,7 +617,6 @@ dependencies = [
 name = "vmnl"
 version = "0.1.0"
 dependencies = [
- "libc",
  "vmnl_native",
 ]
 
@@ -1394,7 +647,7 @@ dependencies = [
  "heck",
  "indexmap",
  "libloading",
- "nom 7.1.3",
+ "nom",
  "once_cell",
  "parking_lot",
  "proc-macro2",
@@ -1438,66 +691,6 @@ dependencies = [
  "syn",
  "vulkano",
 ]
-
-[[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -1546,12 +739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,12 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
-name = "y4m"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
-
-[[package]]
 name = "zerocopy"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,42 +805,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
-dependencies = [
- "zune-core 0.5.1",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ resolver = "2"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+rust-version = "1.87"
+repository = "https://github.com/VMNL/vmnl"
+homepage = "https://github.com/VMNL/vmnl"
+documentation = "https://docs.rs/vmnl"
 
 [profile.dev]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -129,20 +129,32 @@ Constraint: **no hidden complexity, only structured complexity.**
 
 ## 📦 Build
 
+### Install
+
+```bash
+cargo add vmnl
+```
+
+### Minimal usage
+
+```rust
+use vmnl::*;
+```
+
+### From source
+
+```bash
+git clone https://github.com/VMNL/vmnl.git
+cd vmnl
+cargo build
+```
+
 ### Requirements
 
 - Rust (stable)
 - Cargo
 - Vulkan loader (`libvulkan.so`, `vulkan-1.dll`, etc.)
 - Vulkan-compatible GPU
-
-### Run
-
-```bash
-git clone git@github.com:VMNL/vmnl.git
-cd vmnl
-cargo run
-```
 
 ---
 

--- a/crates/vmnl/Cargo.toml
+++ b/crates/vmnl/Cargo.toml
@@ -3,12 +3,14 @@ name    = "vmnl"
 version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
 readme = "../../README.md"
 description = "VMNL public API crate."
+keywords = ["vulkan", "graphics", "windowing", "rendering"]
+categories = ["graphics", "rendering", "game-development"]
 
 [dependencies]
-libc = "0.2.182"
 vmnl_native = { path = "../vmnl_native", version = "0.1.0" }
-
-[lib]
-crate-type = ["rlib", "cdylib"]

--- a/crates/vmnl_native/Cargo.toml
+++ b/crates/vmnl_native/Cargo.toml
@@ -3,8 +3,14 @@ name = "vmnl_native"
 version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+rust-version = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+documentation = "https://docs.rs/vmnl_native"
 readme = "../../README.md"
 description = "VMNL native backend (Vulkan/GLFW)."
+keywords = ["vulkan", "graphics", "glfw", "rendering"]
+categories = ["graphics", "rendering", "game-development"]
 
 [lib]
 doctest = false
@@ -12,7 +18,7 @@ doctest = false
 [dependencies]
 vulkano         = "0.35.2"
 vulkano-shaders = "0.35"
-glfw            = "0.62.0"
+glfw            = { version = "0.62.0", default-features = false, features = ["prebuilt-libs", "raw-window-handle-v0-6", "vulkan", "wayland", "x11"] }
 bytemuck        = "1.25.0"
 log             = "0.4"
 shaderc         = "0.8.3"

--- a/crates/vmnl_native/src/graphics/mod.rs
+++ b/crates/vmnl_native/src/graphics/mod.rs
@@ -8,7 +8,7 @@
 pub mod shape;
 use crate::{VMNLError, VMNLErrorKind, VMNLResult};
 use bytemuck::{Pod, Zeroable};
-pub(crate) use shape::VertexBuffer;
+pub(crate) use shape::{GpuVertex, VertexBuffer};
 pub use shape::{LineCap, Shape, Vertex};
 use std::cmp::Ordering;
 use std::sync::Arc;
@@ -23,13 +23,61 @@ pub type VMNLIndexBuffer = Subbuffer<[u32]>;
 /// Uniform buffer object for frame data.
 #[allow(dead_code)]
 pub type VMNLFrameUboBuffer = Subbuffer<VMNLFrameUbo>;
-/// RGBA color represented as `[r, g, b, a]` (f32).
-pub type Rgba = [f32; 4];
+/// RGBA color represented as 8-bit components.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod, Zeroable, PartialEq, Eq)]
+pub struct Rgba {
+    /// Red component of the color, in the range `[0, 255]`.
+    pub r: u8,
+    /// Green component of the color, in the range `[0, 255]`.
+    pub g: u8,
+    /// Blue component of the color, in the range `[0, 255]`.
+    pub b: u8,
+    /// Alpha component of the color, in the range `[0, 255]`, where `0` is fully transparent and `255` is fully opaque.
+    pub a: u8,
+}
+
+impl Rgba {
+    /// Create a new `Rgba` color from individual components.
+    ///
+    /// # Arguments
+    /// - `r`: Red component of the color, in the range `[0, 255]`.
+    /// - `g`: Green component of the color, in the range `[0, 255]`.
+    /// - `b`: Blue component of the color, in the range `[0, 255]`.
+    /// - `a`: Alpha component of the color, in the range `[0, 255]`, where `0` is fully transparent and `255` is fully opaque.
+    ///
+    /// # Returns
+    /// A new `Rgba` instance representing the specified color.
+    /// # Example
+    /// ```rust
+    /// use vmnl_native::Rgba;
+    /// let color = Rgba::new(255, 0, 0, 255); /// Creates a fully opaque red color.
+    /// ```
+    pub const fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self { r, g, b, a }
+    }
+
+    /// Normalize the RGBA color components to the range `[0.0, 1.0]` for use in shader uniforms.
+    ///
+    /// # Returns
+    /// An array of four `f32` values representing the normalized RGBA color,
+    /// where each component is in the range `[0.0, 1.0]`.
+    pub(crate) fn normalized(self) -> [f32; 4] {
+        [
+            f32::from(self.r) / 255.0,
+            f32::from(self.g) / 255.0,
+            f32::from(self.b) / 255.0,
+            f32::from(self.a) / 255.0,
+        ]
+    }
+}
 /// 2D vector of `f32` values.
 #[derive(Clone, Copy, Debug, Default, Pod, Zeroable, PartialEq)]
 #[repr(C)]
 pub struct Vector2f {
+    /// X component of the vector.
     pub x: f32,
+    /// Y component of the vector.
     pub y: f32,
 }
 
@@ -49,7 +97,6 @@ impl PartialOrd for Vector2f {
     }
 }
 
-/// Information about a connected monitor.
 #[repr(C)]
 #[derive(BufferContents, Clone, Copy, Debug, Default, PartialEq)]
 #[allow(dead_code)]
@@ -184,7 +231,7 @@ pub(crate) trait GraphicsResourceFactory {
         memory_allocator: &Arc<StandardMemoryAllocator>,
     ) -> VMNLResult<VertexBuffer> {
         Self::create_buffer_from_iter(
-            vertices.iter().copied(),
+            vertices.iter().copied().map(GpuVertex::from),
             BufferUsage::VERTEX_BUFFER,
             memory_allocator,
             VMNLErrorKind::VulkanVertexBufferCreationFailed,

--- a/crates/vmnl_native/src/graphics/shape/indexed.rs
+++ b/crates/vmnl_native/src/graphics/shape/indexed.rs
@@ -38,13 +38,13 @@ impl IndexedShapeBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Shape, Vector2f, Vertex};
+    /// # use vmnl_native::{Context, Rgba, Shape, Vector2f, Vertex};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let vertices = [
-    ///     Vertex { position: Vector2f { x: 100.0, y: 100.0 }, color: [255.0, 0.0, 0.0, 255.0] },
-    ///     Vertex { position: Vector2f { x: 300.0, y: 100.0 }, color: [0.0, 255.0, 0.0, 255.0] },
-    ///     Vertex { position: Vector2f { x: 200.0, y: 300.0 }, color: [0.0, 0.0, 255.0, 255.0] },
+    ///     Vertex { position: Vector2f { x: 100.0, y: 100.0 }, color: Rgba::new(255, 0, 0, 255) },
+    ///     Vertex { position: Vector2f { x: 300.0, y: 100.0 }, color: Rgba::new(0, 255, 0, 255) },
+    ///     Vertex { position: Vector2f { x: 200.0, y: 300.0 }, color: Rgba::new(0, 0, 255, 255) },
     /// ];
     /// let indices = [0, 1, 2];
     ///
@@ -92,14 +92,6 @@ impl IndexedShapeBuilder {
             ))));
         }
 
-        let vertices: Vec<Vertex> = vertices
-            .iter()
-            .map(|vertex| Vertex {
-                position: vertex.position,
-                color: Shape::color_transform(vertex.color),
-            })
-            .collect();
-
         println!(
             "{}",
             crate::vmnl_log(format!(
@@ -111,11 +103,11 @@ impl IndexedShapeBuilder {
                     .join("], ["),
                 vertices
                     .iter()
-                    .map(|v| (v.color[0] * 255.0).to_string()
+                    .map(|v| v.color.r.to_string()
                         + ", "
-                        + &(v.color[1] * 255.0).to_string()
+                        + &v.color.g.to_string()
                         + ", "
-                        + &(v.color[2] * 255.0).to_string())
+                        + &v.color.b.to_string())
                     .collect::<Vec<String>>()
                     .join("], ["),
                 indices
@@ -130,7 +122,7 @@ impl IndexedShapeBuilder {
             vertex_count: vertices.len() as u32,
             index_count: indices.len() as u32,
             vertex_buffer: Shape::create_vertex_buffer(
-                &vertices,
+                vertices.iter().as_slice(),
                 &vmnl_context.inner.memory_allocator,
             )?,
             index_buffer: Some(Shape::create_index_buffer(

--- a/crates/vmnl_native/src/graphics/shape/line.rs
+++ b/crates/vmnl_native/src/graphics/shape/line.rs
@@ -49,7 +49,12 @@ impl Default for LineOptions {
             to: Vector2f { x: 0.0, y: 0.0 },
             width: 1.0,
             cap: LineCap::Butt,
-            color: [255.0, 255.0, 255.0, 255.0],
+            color: Rgba {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
         }
     }
 }
@@ -72,7 +77,7 @@ impl LineBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Shape, Vector2f};
+    /// # use vmnl_native::{Context, Rgba, Shape, Vector2f};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let line = Shape::line(Vector2f { x: 100.0, y: 150.0 }, Vector2f { x: 300.0, y: 150.0 })
@@ -93,7 +98,7 @@ impl LineBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, LineCap, Shape, Vector2f};
+    /// # use vmnl_native::{Context, LineCap, Rgba, Shape, Vector2f};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let line = Shape::line(Vector2f { x: 100.0, y: 150.0 }, Vector2f { x: 300.0, y: 150.0 })
@@ -114,11 +119,11 @@ impl LineBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Shape, Vector2f};
+    /// # use vmnl_native::{Context, Rgba, Shape, Vector2f};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let line = Shape::line(Vector2f { x: 100.0, y: 150.0 }, Vector2f { x: 300.0, y: 150.0 })
-    ///     .color([0.0, 0.0, 255.0, 255.0])
+    ///     .color(Rgba::new(0, 0, 255, 255))
     ///     .build(&context)?;
     /// # Ok(())
     /// # }
@@ -136,20 +141,20 @@ impl LineBuilder {
     /// - `to`: Ending point of the line as a `Vector2f`.
     /// - `width`: Optional width of the line (default is `1.0`).
     /// - `cap`: Optional line cap style (default is `LineCap::Butt`).
-    /// - `color`: Optional RGBA color of the line (default is white `[255.0, 255.0, 255.0, 255.0]`).
+    /// - `color`: Optional RGBA color of the line (default is white `Rgba::new(255, 255, 255, 255)`).
     ///
     /// # Returns
     /// A `Shape` instance representing the line, ready for rendering.
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, LineCap, Shape, Vector2f};
+    /// # use vmnl_native::{Context, LineCap, Rgba, Shape, Vector2f};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let line = Shape::line(Vector2f { x: 100.0, y: 150.0 }, Vector2f { x: 300.0, y: 150.0 })
     ///     .width(5.0)
     ///     .cap(LineCap::Round)
-    ///     .color([0.0, 0.0, 255.0, 255.0])
+    ///     .color(Rgba::new(0, 0, 255, 255))
     ///     .build(&context)?;
     /// # Ok(())
     /// # }
@@ -175,7 +180,7 @@ impl LineBuilder {
     /// - `to`: Ending point of the line as a `Vector2f`.
     /// - `width`: Optional width of the line (default is `1.0`).
     /// - `cap`: Optional line cap style (default is `LineCap::Butt`).
-    /// - `color`: Optional RGBA color of the line (default is white `[255.0, 255.0, 255.0, 255.0]`).
+    /// - `color`: Optional RGBA color of the line (default is white `Rgba::new(255, 255, 255, 255)`).
     ///
     /// # Returns
     /// A `Shape` instance representing the line, ready for rendering.

--- a/crates/vmnl_native/src/graphics/shape/mod.rs
+++ b/crates/vmnl_native/src/graphics/shape/mod.rs
@@ -14,7 +14,6 @@ use super::{
     Drawable, GraphicsResourceFactory, MaterialKey, PipelineKey, RenderItem, Rgba, VMNLIndexBuffer,
     Vector2f,
 };
-use crate::{VMNLError, VMNLErrorKind};
 use bytemuck::{Pod, Zeroable};
 use indexed::IndexedShapeBuilder;
 pub use line::{LineBuilder, LineCap};
@@ -22,8 +21,8 @@ pub use rect::RectBuilder;
 pub use triangle::TriangleBuilder;
 use vulkano::{buffer::Subbuffer, pipeline::graphics::vertex_input::Vertex as VulkanoVertex};
 
-/// Alias for a vertex buffer containing `Vertex` instances.
-pub(crate) type VertexBuffer = Subbuffer<[Vertex]>;
+/// Alias for a vertex buffer containing GPU-ready vertices.
+pub(crate) type VertexBuffer = Subbuffer<[GpuVertex]>;
 
 /// Types of shape data that can be rendered in VMNL.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -40,26 +39,45 @@ pub enum ShapeKind {
     // Circle,
 }
 
-/// Vertex with a 2D position and Rgba color.
+/// Public vertex with a 2D position and 8-bit RGBA color.
 ///
 /// # Example
 /// ```rust
-/// use vmnl_native::{Vector2f, Vertex};
+/// use vmnl_native::{Rgba, Vector2f, Vertex};
 ///
 /// let vertex = Vertex {
 ///     position: Vector2f { x: 100.0, y: 150.0 },
-///     color: [255.0, 0.0, 0.0, 255.0],
+///     color: Rgba { r: 255, g: 0, b: 0, a: 255 },
 /// };
 /// ```
 #[repr(C)]
-#[derive(VulkanoVertex, Pod, Zeroable, Clone, Copy, Default, Debug, PartialEq)]
+#[derive(Pod, Zeroable, Clone, Copy, Default, Debug, PartialEq)]
 pub struct Vertex {
+    /// Position of the vertex as `[x, y]`.
+    pub position: Vector2f,
+    /// Color of the vertex as `[r, g, b, a]`.
+    pub color: Rgba,
+}
+
+/// GPU vertex format with position and normalized color, used for vertex buffers.
+#[repr(C)]
+#[derive(VulkanoVertex, Pod, Zeroable, Clone, Copy, Default, Debug, PartialEq)]
+pub(crate) struct GpuVertex {
     /// Position of the vertex as `[x, y]`.
     #[format(R32G32_SFLOAT)]
     pub position: Vector2f,
-    /// Color of the vertex as `[r, g, b, a]`.
+    /// Normalized color of the vertex as `[r, g, b, a]`, where each component is in the range `[0.0, 1.0]`.
     #[format(R32G32B32A32_SFLOAT)]
-    pub color: Rgba,
+    pub color: [f32; 4],
+}
+
+impl From<Vertex> for GpuVertex {
+    fn from(vertex: Vertex) -> Self {
+        Self {
+            position: vertex.position,
+            color: vertex.color.normalized(),
+        }
+    }
 }
 
 /// Shape resource container holding vertex/index buffers and counts.
@@ -108,12 +126,12 @@ impl Shape {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Shape};
+    /// # use vmnl_native::{Context, Rgba, Shape};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let rectangle = Shape::rect(200.0, 100.0)
     ///     .position(100.0, 150.0)
-    ///     .color([255.0, 0.0, 0.0, 255.0])
+    ///     .color(Rgba::new(255, 0, 0, 255))
     ///     .build(&context)?;
     /// # Ok(())
     /// # }
@@ -128,13 +146,13 @@ impl Shape {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Shape, Vector2f, Vertex};
+    /// # use vmnl_native::{Context, Rgba, Shape, Vector2f, Vertex};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let vertices = [
-    ///     Vertex { position: Vector2f { x: 100.0, y: 100.0 }, color: [255.0, 0.0, 0.0, 255.0] },
-    ///     Vertex { position: Vector2f { x: 300.0, y: 100.0 }, color: [0.0, 255.0, 0.0, 255.0] },
-    ///     Vertex { position: Vector2f { x: 200.0, y: 300.0 }, color: [0.0, 0.0, 255.0, 255.0] },
+    ///     Vertex { position: Vector2f { x: 100.0, y: 100.0 }, color: Rgba::new(255, 0, 0, 255) },
+    ///     Vertex { position: Vector2f { x: 300.0, y: 100.0 }, color: Rgba::new(0, 255, 0, 255) },
+    ///     Vertex { position: Vector2f { x: 200.0, y: 300.0 }, color: Rgba::new(0, 0, 255, 255) },
     /// ];
     /// let indices = [0, 1, 2];
     ///
@@ -155,20 +173,20 @@ impl Shape {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Shape, Vector2f, Vertex};
+    /// # use vmnl_native::{Context, Rgba, Shape, Vector2f, Vertex};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let vertex1 = Vertex {
     ///     position: Vector2f { x: 100.0, y: 150.0 },
-    ///     color: [255.0, 0.0, 0.0, 255.0],
+    ///     color: Rgba::new(255, 0, 0, 255),
     /// };
     /// let vertex2 = Vertex {
     ///     position: Vector2f { x: 300.0, y: 150.0 },
-    ///     color: [0.0, 255.0, 0.0, 255.0],
+    ///     color: Rgba::new(0, 255, 0, 255),
     /// };
     /// let vertex3 = Vertex {
     ///     position: Vector2f { x: 200.0, y: 300.0 },
-    ///     color: [0.0, 0.0, 255.0, 255.0],
+    ///     color: Rgba::new(0, 0, 255, 255),
     /// };
     /// let triangle = Shape::triangle([vertex1, vertex2, vertex3])
     ///     .build(&context)?;
@@ -185,38 +203,19 @@ impl Shape {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, LineCap, Shape, Vector2f};
+    /// # use vmnl_native::{Context, LineCap, Rgba, Shape, Vector2f};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let line = Shape::line(Vector2f { x: 100.0, y: 150.0 }, Vector2f { x: 300.0, y: 150.0 })
     ///     .width(5.0)
     ///     .cap(LineCap::Round)
-    ///     .color([0.0, 0.0, 255.0, 255.0])
+    ///     .color(Rgba::new(0, 0, 255, 255))
     ///     .build(&context)?;
     /// # Ok(())
     /// # }
     /// ```
     pub fn line(from: Vector2f, to: Vector2f) -> LineBuilder {
         LineBuilder::new(from, to)
-    }
-
-    /// Transform color values from `[0, 255]` to `[0.0, 1.0]` expected by Vulkan.
-    fn color_transform(color: Rgba) -> Rgba {
-        if color.iter().any(|&c| c > 255.0) {
-            eprintln!(
-                "{}",
-                VMNLError::new(VMNLErrorKind::InvalidState(
-                    "color value overflow detected".to_string()
-                ))
-                .report()
-            );
-        }
-        [
-            (color[0] / 255.0).clamp(0.0, 1.0),
-            (color[1] / 255.0).clamp(0.0, 1.0),
-            (color[2] / 255.0).clamp(0.0, 1.0),
-            (color[3] / 255.0).clamp(0.0, 1.0),
-        ]
     }
 }
 

--- a/crates/vmnl_native/src/graphics/shape/rect.rs
+++ b/crates/vmnl_native/src/graphics/shape/rect.rs
@@ -24,7 +24,12 @@ impl Default for RectOptions {
         Self {
             position: Vector2f { x: 0.0, y: 0.0 },
             size: Vector2f { x: 0.0, y: 0.0 },
-            color: [255.0, 255.0, 255.0, 255.0],
+            color: Rgba {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
         }
     }
 }
@@ -55,7 +60,7 @@ impl RectBuilder {
     /// The updated `RectBuilder` instance with the specified position.
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Shape};
+    /// # use vmnl_native::{Context, Rgba, Shape};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let rect = Shape::rect(100.0, 100.0)
@@ -79,11 +84,15 @@ impl RectBuilder {
     /// The updated `RectBuilder` instance with the specified color.
     ///
     /// # Example
-    /// ```rust
-    /// use vmnl_native::Shape;
-    ///
+    /// ```rust,no_run
+    /// # use vmnl_native::{Context, Rgba, Shape};
+    /// # fn main() -> vmnl_native::VMNLResult<()> {
+    /// # let context = Context::new()?;
     /// let rect = Shape::rect(100.0, 100.0)
-    ///     .color([255.0, 0.0, 0.0, 255.0]);
+    ///     .color(Rgba::new(255, 0, 0, 255))
+    ///     .build(&context)?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn color(mut self, color: Rgba) -> Self {
         self.options.color = color;
@@ -99,7 +108,7 @@ impl RectBuilder {
     /// A `Shape` instance representing the rectangle, ready for rendering.
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Shape};
+    /// # use vmnl_native::{Context, Rgba, Shape};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let rect = Shape::rect(100.0, 100.0)
@@ -168,6 +177,11 @@ impl RectBuilder {
         let y0: f32 = position.y;
         let x1: f32 = x0 + size.x;
         let y1: f32 = y0 + size.y;
+        if x1.is_infinite() || y1.is_infinite() {
+            return Err(VMNLError::new(VMNLErrorKind::InvalidState(
+                "rectangle bounds must be finite".to_string(),
+            )));
+        }
         let vertices: [Vertex; 4] = [
             Vertex {
                 position: Vector2f { x: x0, y: y0 },
@@ -194,7 +208,7 @@ impl RectBuilder {
         println!("{}", crate::vmnl_log(format!("Creating rectangle at position [{}, {}] with size [{}, {}] and color [{}, {}, {}].",
             position.x, position.y,
             size.x, size.y,
-            color[0], color[1], color[2]
+            color.r, color.g, color.b
         )));
         Ok(graphics)
     }

--- a/crates/vmnl_native/src/graphics/shape/triangle.rs
+++ b/crates/vmnl_native/src/graphics/shape/triangle.rs
@@ -5,9 +5,7 @@
 /// Vertex utilities for the VMNL graphics module.
 ////////////////////////////////////////////////////////////////////////////////
 use super::{Shape, ShapeKind::RawVertices, Vertex};
-use crate::{
-    graphics::GraphicsResourceFactory, Context, Rgba, VMNLError, VMNLErrorKind, VMNLResult,
-};
+use crate::{graphics::GraphicsResourceFactory, Context, VMNLError, VMNLErrorKind, VMNLResult};
 
 pub struct TriangleBuilder {
     vertices: [Vertex; 3],
@@ -28,20 +26,20 @@ impl TriangleBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Shape, Vector2f, Vertex};
+    /// # use vmnl_native::{Context, Rgba, Shape, Vector2f, Vertex};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let vertex1 = Vertex {
     ///     position: Vector2f { x: 100.0, y: 150.0 },
-    ///     color: [255.0, 0.0, 0.0, 255.0],
+    ///     color: Rgba::new(255, 0, 0, 255),
     /// };
     /// let vertex2 = Vertex {
     ///     position: Vector2f { x: 300.0, y: 150.0 },
-    ///     color: [0.0, 255.0, 0.0, 255.0],
+    ///     color: Rgba::new(0, 255, 0, 255),
     /// };
     /// let vertex3 = Vertex {
     ///     position: Vector2f { x: 200.0, y: 300.0 },
-    ///     color: [0.0, 0.0, 255.0, 255.0],
+    ///     color: Rgba::new(0, 0, 255, 255),
     /// };
     /// let triangle = Shape::triangle([vertex1, vertex2, vertex3])
     ///     .build(&context)?;
@@ -50,7 +48,7 @@ impl TriangleBuilder {
     /// ```
     pub fn build(self, vmnl_context: &Context) -> VMNLResult<Shape> {
         let [a, b, c] = self.vertices;
-        Self::triangle(vmnl_context, a, b, c)
+        Self::triangle(vmnl_context, [a, b, c])
     }
 
     /// Create a `Shape` instance by transforming the input vertices into a vertex buffer.
@@ -61,12 +59,8 @@ impl TriangleBuilder {
     ///
     /// # Returns
     /// A `Shape` instance with a created vertex buffer ready for rendering.
-    fn triangle(
-        vmnl_context: &Context,
-        vertex1: Vertex,
-        vertex2: Vertex,
-        vertex3: Vertex,
-    ) -> VMNLResult<Shape> {
+    fn triangle(vmnl_context: &Context, vertex: [Vertex; 3]) -> VMNLResult<Shape> {
+        let [vertex1, vertex2, vertex3] = vertex;
         if vertex1.position == vertex2.position
             || vertex1.position == vertex3.position
             || vertex2.position == vertex3.position
@@ -76,21 +70,18 @@ impl TriangleBuilder {
             )));
         }
 
-        let vertex1_color: Rgba = Shape::color_transform(vertex1.color);
-        let vertex2_color: Rgba = Shape::color_transform(vertex2.color);
-        let vertex3_color: Rgba = Shape::color_transform(vertex3.color);
         let vertices = [
             Vertex {
                 position: vertex1.position,
-                color: vertex1_color,
+                color: vertex1.color,
             },
             Vertex {
                 position: vertex2.position,
-                color: vertex2_color,
+                color: vertex2.color,
             },
             Vertex {
                 position: vertex3.position,
-                color: vertex3_color,
+                color: vertex3.color,
             },
         ];
 
@@ -99,9 +90,9 @@ impl TriangleBuilder {
             vertex1.position.x, vertex1.position.y,
             vertex2.position.x, vertex2.position.y,
             vertex3.position.x, vertex3.position.y,
-            vertex1.color[0], vertex1.color[1], vertex1.color[2], vertex1.color[3],
-            vertex2.color[0], vertex2.color[1], vertex2.color[2], vertex2.color[3],
-            vertex3.color[0], vertex3.color[1], vertex3.color[2], vertex3.color[3]
+            vertex1.color.r, vertex1.color.g, vertex1.color.b, vertex1.color.a,
+            vertex2.color.r, vertex2.color.g, vertex2.color.b, vertex2.color.a,
+            vertex3.color.r, vertex3.color.g, vertex3.color.b, vertex3.color.a
         )));
         Ok(Shape {
             kind: RawVertices,

--- a/crates/vmnl_native/src/vmnl_instance.rs
+++ b/crates/vmnl_native/src/vmnl_instance.rs
@@ -36,7 +36,6 @@ pub struct Context {
     /// Inner `VMNLInstance` containing the Vulkan context and resources.
     /// Wrapped in an `Rc` for shared ownership within a single thread.
     pub(crate) inner: Rc<VMNLInstance>,
-    _not_send_sync: std::marker::PhantomData<std::rc::Rc<()>>,
 }
 
 impl Context {
@@ -51,7 +50,7 @@ impl Context {
     ///
     /// # Example
     /// ```rust,no_run
-    /// use vmnl_native::{Context, Shape, Vector2f, Vertex, Window};
+    /// use vmnl_native::{Context, Rgba, Shape, Vector2f, Vertex, Window};
     ///
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// let context = Context::new()?;
@@ -61,9 +60,9 @@ impl Context {
     ///     .build(&context)?;
     ///
     /// let triangle = Shape::triangle([
-    ///     Vertex { position: Vector2f { x: 100.0, y: 100.0 }, color: [255.0, 0.0, 0.0, 255.0] },
-    ///     Vertex { position: Vector2f { x: 300.0, y: 100.0 }, color: [0.0, 255.0, 0.0, 255.0] },
-    ///     Vertex { position: Vector2f { x: 200.0, y: 300.0 }, color: [0.0, 0.0, 255.0, 255.0] },
+    ///     Vertex { position: Vector2f { x: 100.0, y: 100.0 }, color: Rgba::new(255, 0, 0, 255) },
+    ///     Vertex { position: Vector2f { x: 300.0, y: 100.0 }, color: Rgba::new(0, 255, 0, 255) },
+    ///     Vertex { position: Vector2f { x: 200.0, y: 300.0 }, color: Rgba::new(0, 0, 255, 255) },
     /// ])
     /// .build(&context)?;
     ///
@@ -79,7 +78,6 @@ impl Context {
     pub fn new() -> VMNLResult<Self> {
         Ok(Self {
             inner: Rc::new(VMNLInstance::new()?),
-            _not_send_sync: std::marker::PhantomData,
         })
     }
 }

--- a/crates/vmnl_native/src/window/api.rs
+++ b/crates/vmnl_native/src/window/api.rs
@@ -23,7 +23,7 @@ impl<const N: usize> RenderCall<'_, '_, N> {
     /// ```rust,ignore
     /// let background = Shape::rect(200.0, 100.0)
     ///     .position(100.0, 150.0)
-    ///     .color([255.0, 0.0, 0.0, 255.0])
+    ///     .color(Rgba::new(255, 0, 0, 255))
     ///     .build(&context)?;
     ///
     /// while window.is_open() {
@@ -47,7 +47,7 @@ impl<const N: usize> RenderCall<'_, '_, N> {
     /// ```rust,ignore
     /// let background = Shape::rect(200.0, 100.0)
     ///     .position(100.0, 150.0)
-    ///     .color([255.0, 0.0, 0.0, 255.0])
+    ///     .color(Rgba::new(255, 0, 0, 255))
     ///     .build(&context)?;
     ///
     /// while window.is_open() {
@@ -73,7 +73,7 @@ impl Window {
     /// ```rust,ignore
     /// let background = Shape::rect(200.0, 100.0)
     ///     .position(100.0, 150.0)
-    ///     .color([255.0, 0.0, 0.0, 255.0])
+    ///     .color(Rgba::new(255, 0, 0, 255))
     ///     .build(&context)?;
     ///
     /// while window.is_open() {
@@ -1330,14 +1330,11 @@ impl Window {
     ///
     /// # Example
     /// ```rust,ignore
-    /// window.set_clear_color([255.0, 0.0, 0.0, 255.0]);
-    /// window.set_clear_color([0.0, 0.0, 255.0, 128.0]);
+    /// window.set_clear_color(Rgba::new(255, 0, 0, 255));
+    /// window.set_clear_color(Rgba::new(0, 0, 255, 128));
     /// ```
     #[inline]
     pub fn set_clear_color(&mut self, color: Rgba) {
-        let [r, g, b, a] = color;
-
-        self.inner
-            .set_clear_color([r / 255.0, g / 255.0, b / 255.0, a / 255.0]);
+        self.inner.set_clear_color(color.normalized());
     }
 }

--- a/crates/vmnl_native/src/window/inner.rs
+++ b/crates/vmnl_native/src/window/inner.rs
@@ -8,6 +8,7 @@
 extern crate glfw;
 use super::WindowOptions;
 use crate::exception::{VMNLError, VMNLErrorKind};
+use crate::graphics::GpuVertex;
 use crate::vmnl_instance::VMNLInstance;
 use crate::window::config::WindowConfig;
 use crate::window::event::EventQueue;
@@ -18,7 +19,6 @@ use crate::window::state::WindowState;
 use crate::window::{shaders::fs, shaders::vs, shaders::ShaderInput, shaders::WindowShaders};
 use crate::Context;
 use crate::VMNLResult;
-use crate::Vertex;
 use std::rc::Rc;
 use std::sync::Arc;
 use vulkano::{
@@ -396,7 +396,7 @@ impl VMNLWindow {
         .map_err(|_| VMNLError::new(VMNLErrorKind::VulkanPipelineLayoutCreationFailed))?;
         let subpass: Subpass = Subpass::from(render_pass.clone(), 0)
             .ok_or_else(|| VMNLError::new(VMNLErrorKind::VulkanRenderPassCreationFailed))?;
-        let vertex_input_state: VertexInputState = Vertex::per_vertex()
+        let vertex_input_state: VertexInputState = GpuVertex::per_vertex()
             .definition(&vs)
             .map_err(|_| VMNLError::new(VMNLErrorKind::VulkanValidationFailed))?;
 

--- a/crates/vmnl_native/src/window/input/keyboard.rs
+++ b/crates/vmnl_native/src/window/input/keyboard.rs
@@ -622,3 +622,9 @@ impl KeyboardState {
         }
     }
 }
+
+impl Default for KeyboardState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/vmnl_native/src/window/input/mod.rs
+++ b/crates/vmnl_native/src/window/input/mod.rs
@@ -85,10 +85,10 @@ impl Input {
 
     /// Creates a new `Input` with fresh keyboard and mouse states.
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            keyboard: KeyboardState::new(),
-            mouse: MouseState::new(),
+            keyboard: KeyboardState::default(),
+            mouse: MouseState::default(),
         }
     }
 }

--- a/crates/vmnl_native/src/window/input/mouse.rs
+++ b/crates/vmnl_native/src/window/input/mouse.rs
@@ -372,3 +372,9 @@ impl MouseState {
         }
     }
 }
+
+impl Default for MouseState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/vmnl_native/src/window/mod.rs
+++ b/crates/vmnl_native/src/window/mod.rs
@@ -130,7 +130,7 @@ impl WindowBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()
@@ -152,7 +152,7 @@ impl WindowBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()
@@ -175,7 +175,7 @@ impl WindowBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()
@@ -213,7 +213,7 @@ impl WindowBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()
@@ -245,7 +245,7 @@ impl WindowBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()
@@ -266,7 +266,7 @@ impl WindowBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()
@@ -288,7 +288,7 @@ impl WindowBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()
@@ -322,7 +322,7 @@ impl WindowBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()
@@ -352,19 +352,17 @@ impl WindowBuilder {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()
-    ///     .set_clear_color([0.0, 0.0, 0.0, 255.0])
+    ///     .set_clear_color(Rgba::new(0, 0, 0, 255))
     ///     .build(&context)?;
     /// # Ok(())
     /// # }
     /// ```
     pub fn set_clear_color(mut self, clear_color: Rgba) -> Self {
-        let [r, g, b, a] = clear_color;
-
-        self.options.clear_color = [r / 255.0, g / 255.0, b / 255.0, a / 255.0];
+        self.options.clear_color = clear_color.normalized();
         self
     }
 
@@ -398,7 +396,7 @@ impl Window {
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use vmnl_native::{Context, Window};
+    /// # use vmnl_native::{Context, Rgba, Window};
     /// # fn main() -> vmnl_native::VMNLResult<()> {
     /// # let context = Context::new()?;
     /// let window = Window::builder()

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,2 +1,28 @@
-- A guide describing how is set up your repository and CI/CD pipeline that can be
-used to build, test and deploy your project
+# Deployment
+
+## crates.io release
+
+Required secret:
+
+- `CARGO_REGISTRY_TOKEN`: crates.io API token with publish permission.
+
+Manual checks before tagging:
+
+```bash
+cargo test --workspace
+cargo doc -p vmnl --no-deps
+cargo publish -p vmnl_native --dry-run
+cargo package -p vmnl --list
+```
+
+Publish order:
+
+```bash
+cargo publish -p vmnl_native
+sleep 60
+cargo publish -p vmnl --dry-run
+cargo publish -p vmnl
+```
+
+`vmnl_native` must be visible in the crates.io index before `vmnl` can be
+published, because `vmnl` depends on `vmnl_native` by version.

--- a/examples/test/src/main.rs
+++ b/examples/test/src/main.rs
@@ -1,4 +1,8 @@
-use vmnl::{Context, Event, Key, MouseButton, Shape, VMNLResult, Vector2f, Vertex, Window};
+use vmnl::{Context, Event, Key, MouseButton, Rgba, Shape, VMNLResult, Vector2f, Vertex, Window};
+
+const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Rgba {
+    Rgba { r, g, b, a }
+}
 
 fn handle_event_test(event: &Event) {
     match event {
@@ -76,32 +80,32 @@ fn create_pentagon_indexed(ctx: &Context) -> VMNLResult<Shape> {
         // Center
         Vertex {
             position: Vector2f { x: 700.0, y: 600.0 },
-            color: [255.0, 255.0, 255.0, 255.0],
+            color: rgba(255, 255, 255, 255),
         },
         // Top
         Vertex {
             position: Vector2f { x: 700.0, y: 350.0 },
-            color: [255.0, 0.0, 0.0, 255.0],
+            color: rgba(255, 0, 0, 255),
         },
         // Upper right
         Vertex {
             position: Vector2f { x: 938.0, y: 523.0 },
-            color: [255.0, 255.0, 0.0, 255.0],
+            color: rgba(255, 255, 0, 255),
         },
         // Lower right
         Vertex {
             position: Vector2f { x: 847.0, y: 802.0 },
-            color: [0.0, 255.0, 0.0, 255.0],
+            color: rgba(0, 255, 0, 255),
         },
         // Lower left
         Vertex {
             position: Vector2f { x: 553.0, y: 802.0 },
-            color: [0.0, 255.0, 255.0, 255.0],
+            color: rgba(0, 255, 255, 255),
         },
         // Upper left
         Vertex {
             position: Vector2f { x: 462.0, y: 523.0 },
-            color: [0.0, 0.0, 255.0, 255.0],
+            color: rgba(0, 0, 255, 255),
         },
     ];
     const INDICES: [u32; 15] = [
@@ -120,7 +124,7 @@ fn main() -> VMNLResult<()> {
     let mut win: Window = Window::builder()
         .size(1920, 1080)
         .size_limit(Some(600), Some(600), Some(2000), Some(1500))?
-        .set_clear_color([0.0, 0.0, 0.0, 255.0])
+        .set_clear_color(rgba(0, 0, 0, 255))
         .build(&ctx)?;
     let triangle: Shape = Shape::triangle([
         Vertex {
@@ -128,28 +132,28 @@ fn main() -> VMNLResult<()> {
                 x: 1200.0,
                 y: 300.0,
             },
-            color: [255.0, 0.0, 0.0, 255.0],
+            color: rgba(255, 0, 0, 255),
         },
         Vertex {
             position: Vector2f {
                 x: 1600.0,
                 y: 300.0,
             },
-            color: [0.0, 255.0, 0.0, 255.0],
+            color: rgba(0, 255, 0, 255),
         },
         Vertex {
             position: Vector2f {
                 x: 1200.0,
                 y: 500.0,
             },
-            color: [0.0, 0.0, 255.0, 255.0],
+            color: rgba(0, 0, 255, 255),
         },
     ])
     .build(&ctx)?;
     let pentagon_indexed: Shape = create_pentagon_indexed(&ctx)?;
     let rectangle: Shape = Shape::rect(800.0, 100.0)
         .position(100.0, 150.0)
-        .color([255.0, 0.0, 0.0, 255.0])
+        .color(rgba(255, 0, 0, 255))
         .build(&ctx)?;
 
     println!(


### PR DESCRIPTION
## Summary

This PR changes the client-facing color API from `[f32; 4]` to an explicit `Rgba` struct using `u8` components.

## Changes

- Replace public `Rgba = [f32; 4]` with `Rgba { r, g, b, a }`.
- Add `Rgba::new(r, g, b, a)` constructor.
- Keep GPU-facing colors as normalized `[f32; 4]`.
- Convert colors internally through `Rgba::normalized()`.
- Update shape vertices, clear color APIs, docs, and examples to use `Rgba`.

## Motivation

Client code now uses the standard `0..=255` RGBA representation instead of manually passing float color values.  
The rendering backend still receives normalized float colors, so the Vulkan/shader format stays unchanged.

## Breaking change

Color inputs must now use:

```rust
Rgba::new(255, 0, 0, 255)
```

close #38