### PR TITLE
feat: add raw uniform support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw_uniform"
+version = "0.1.0"
+dependencies = [
+ "vmnl",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "examples/d2_shapes",
     "examples/raw_pipeline",
     "examples/raw_triangle",
+    "examples/raw_uniform",
     "examples/window_custom_shaders",
     "examples/window_events_input",
     "tests/api",

--- a/crates/vmnl_graphics/src/raw/mod.rs
+++ b/crates/vmnl_graphics/src/raw/mod.rs
@@ -3,13 +3,19 @@
 
 //! Low-level raw rendering API.
 
+use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 pub use vmnl_macros::{Pod, Vertex, Zeroable};
 
 use vulkano::buffer::BufferContents as VulkanoBufferContents;
+use vulkano::buffer::BufferUsage;
 use vulkano::buffer::Subbuffer;
+use vulkano::descriptor_set::layout::{
+    DescriptorSetLayout, DescriptorSetLayoutCreateInfo, DescriptorType,
+};
+use vulkano::descriptor_set::{DescriptorSet, WriteDescriptorSet};
 use vulkano::device::Device;
 use vulkano::pipeline::graphics::color_blend::{
     AttachmentBlend, ColorBlendAttachmentState, ColorBlendState,
@@ -25,7 +31,8 @@ use vulkano::pipeline::graphics::vertex_input::{
 use vulkano::pipeline::graphics::viewport::ViewportState;
 use vulkano::pipeline::layout::PipelineDescriptorSetLayoutCreateInfo;
 use vulkano::pipeline::{
-    DynamicState, GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
+    DynamicState, GraphicsPipeline, Pipeline as VulkanoPipeline, PipelineLayout,
+    PipelineShaderStageCreateInfo,
 };
 use vulkano::render_pass::{RenderPass, Subpass};
 use vulkano::shader::{ShaderModule, ShaderModuleCreateInfo};
@@ -167,7 +174,7 @@ impl<TVertex> PipelineSpec<TVertex> {
     ///
     /// # Errors
     /// Returns an error if shaders are missing, fail to compile, declare
-    /// descriptors or push constants, or if Vulkan pipeline creation fails.
+    /// unsupported resources or push constants, or if Vulkan pipeline creation fails.
     pub fn build(self, window: &Window) -> VMNLResult<Pipeline<TVertex>>
     where
         TVertex: BufferContents + Vertex + 'static,
@@ -206,13 +213,7 @@ impl<TVertex> PipelineSpec<TVertex> {
         ];
 
         let layout_info = PipelineDescriptorSetLayoutCreateInfo::from_stages(&stages);
-        validate_raw_pipeline_layout(
-            layout_info
-                .set_layouts
-                .iter()
-                .any(|set_layout| !set_layout.bindings.is_empty()),
-            !layout_info.push_constant_ranges.is_empty(),
-        )?;
+        validate_raw_pipeline_layout(&layout_info)?;
 
         let layout = PipelineLayout::new(
             device.clone(),
@@ -274,11 +275,31 @@ impl<TVertex> Pipeline<TVertex> {
     }
 
     pub(crate) fn render_item(&self, geometry: &Geometry<TVertex>) -> RenderItemRaw {
+        self.render_item_with_resources(geometry, None)
+    }
+
+    pub(crate) fn render_item_with(
+        &self,
+        geometry: &Geometry<TVertex>,
+        resources: &Resources,
+    ) -> RenderItemRaw {
+        self.render_item_with_resources(geometry, Some(resources))
+    }
+
+    fn render_item_with_resources(
+        &self,
+        geometry: &Geometry<TVertex>,
+        resources: Option<&Resources>,
+    ) -> RenderItemRaw {
         RenderItemRaw {
             pipeline: self.inner.clone(),
             pipeline_device: self.device.clone(),
             pipeline_render_pass: self.render_pass.clone(),
             geometry_device: geometry.device.clone(),
+            resources_device: resources.map(|resources| resources.device.clone()),
+            resources_pipeline_layout: resources.map(|resources| resources.pipeline_layout.clone()),
+            descriptor_sets: resources.map_or_else(Vec::new, Resources::descriptor_sets),
+            required_descriptor_set_count: required_descriptor_set_count(self.inner.layout()),
             vertex_buffer: geometry.vertex_buffer_bytes(),
             index_buffer: geometry.index_buffer(),
             vertex_count: geometry.vertex_count,
@@ -392,12 +413,187 @@ impl<TVertex> GeometryBuilder<TVertex> {
 
 impl<TVertex> GraphicsResourceFactory for GeometryBuilder<TVertex> {}
 
+/// Typed raw uniform buffer.
+pub struct Uniform<TData> {
+    buffer: Subbuffer<TData>,
+    device: Arc<Device>,
+}
+
+impl<TData> Uniform<TData> {
+    /// Starts a raw uniform buffer builder.
+    #[must_use]
+    pub fn builder(data: TData) -> UniformBuilder<TData> {
+        UniformBuilder {
+            data,
+            memory_preference: BufferMemoryPreference::default(),
+        }
+    }
+
+    fn buffer_bytes(&self) -> Subbuffer<[u8]> {
+        self.buffer.clone().into_bytes()
+    }
+}
+
+/// Builder for typed raw uniform buffers.
+pub struct UniformBuilder<TData> {
+    data: TData,
+    memory_preference: BufferMemoryPreference,
+}
+
+impl<TData> UniformBuilder<TData> {
+    /// Sets the buffer memory preference.
+    #[must_use]
+    pub fn buffer_memory_preference(mut self, preference: BufferMemoryPreference) -> Self {
+        self.memory_preference = preference;
+        self
+    }
+
+    /// Builds a GPU uniform buffer.
+    ///
+    /// # Errors
+    /// Returns an error if GPU buffer allocation fails.
+    pub fn build(self, context: &Context) -> VMNLResult<Uniform<TData>>
+    where
+        TData: BufferContents,
+    {
+        let buffer = <Self as GraphicsResourceFactory>::create_buffer_from_data(
+            self.data,
+            BufferUsage::UNIFORM_BUFFER,
+            self.memory_preference,
+            &context.inner.memory_allocator,
+            VMNLErrorKind::VulkanFrameUboBufferCreationFailed,
+        )?;
+
+        Ok(Uniform {
+            buffer,
+            device: context.inner.device.clone(),
+        })
+    }
+}
+
+impl<TData> GraphicsResourceFactory for UniformBuilder<TData> {}
+
+/// Descriptor resources bound by a raw draw call.
+pub struct Resources {
+    device: Arc<Device>,
+    pipeline_layout: Arc<PipelineLayout>,
+    descriptor_sets: Vec<Arc<DescriptorSet>>,
+}
+
+impl Resources {
+    /// Starts a raw resource builder for a specific pipeline layout.
+    #[must_use]
+    pub fn builder<TVertex>(pipeline: &Pipeline<TVertex>) -> ResourcesBuilder {
+        let pipeline_layout = pipeline.inner.layout().clone();
+        ResourcesBuilder {
+            pipeline_device: pipeline.device.clone(),
+            pipeline_layout: pipeline_layout.clone(),
+            set_layouts: pipeline_layout.set_layouts().to_vec(),
+            bindings: BTreeMap::new(),
+            duplicate_binding: None,
+        }
+    }
+
+    fn descriptor_sets(&self) -> Vec<Arc<DescriptorSet>> {
+        self.descriptor_sets.clone()
+    }
+}
+
+/// Builder for raw descriptor resources.
+pub struct ResourcesBuilder {
+    pipeline_device: Arc<Device>,
+    pipeline_layout: Arc<PipelineLayout>,
+    set_layouts: Vec<Arc<DescriptorSetLayout>>,
+    bindings: BTreeMap<u32, BTreeMap<u32, ResourceBinding>>,
+    duplicate_binding: Option<(u32, u32)>,
+}
+
+impl ResourcesBuilder {
+    /// Binds a uniform buffer to a shader descriptor binding.
+    #[must_use]
+    pub fn uniform<TData>(mut self, set: u32, binding: u32, uniform: &Uniform<TData>) -> Self {
+        let old = self.bindings.entry(set).or_default().insert(
+            binding,
+            ResourceBinding::UniformBuffer {
+                buffer: uniform.buffer_bytes(),
+                device: uniform.device.clone(),
+            },
+        );
+        if old.is_some() && self.duplicate_binding.is_none() {
+            self.duplicate_binding = Some((set, binding));
+        }
+        self
+    }
+
+    /// Builds descriptor sets compatible with the pipeline used by this builder.
+    ///
+    /// # Errors
+    /// Returns an error if a required binding is missing, unsupported, duplicated,
+    /// or if descriptor set allocation fails.
+    pub fn build(mut self, context: &Context) -> VMNLResult<Resources> {
+        validate_resources_context(context, &self.pipeline_device)?;
+        if let Some((set, binding)) = self.duplicate_binding {
+            return Err(VMNLError::new(VMNLErrorKind::InvalidState(format!(
+                "raw resources duplicate binding set {set} binding {binding}"
+            ))));
+        }
+
+        validate_supplied_resource_bindings(&self.set_layouts, &self.bindings)?;
+        let required_set_count = required_descriptor_set_count_from_layouts(&self.set_layouts);
+        let mut descriptor_sets = Vec::with_capacity(required_set_count);
+
+        for set_index in 0..required_set_count {
+            let set = u32::try_from(set_index)
+                .map_err(|_| VMNLError::new(VMNLErrorKind::VulkanValidationFailed))?;
+            let set_layout = self
+                .set_layouts
+                .get(set_index)
+                .cloned()
+                .ok_or_else(|| VMNLError::new(VMNLErrorKind::VulkanValidationFailed))?;
+            let supplied_bindings = self.bindings.remove(&set).unwrap_or_default();
+            let writes = descriptor_writes_for_set(context, set, &set_layout, &supplied_bindings)?;
+            let descriptor_set = DescriptorSet::new(
+                context.inner.descriptor_set_allocator.clone(),
+                set_layout,
+                writes,
+                Vec::new(),
+            )
+            .map_err(|_| VMNLError::new(VMNLErrorKind::VulkanDescriptorSetCreationFailed))?;
+            descriptor_sets.push(descriptor_set);
+        }
+
+        if let Some((&set, _)) = self.bindings.iter().next() {
+            return Err(VMNLError::new(VMNLErrorKind::InvalidState(format!(
+                "raw resources set {set} is not declared by the pipeline"
+            ))));
+        }
+
+        Ok(Resources {
+            device: context.inner.device.clone(),
+            pipeline_layout: self.pipeline_layout,
+            descriptor_sets,
+        })
+    }
+}
+
+#[derive(Clone)]
+enum ResourceBinding {
+    UniformBuffer {
+        buffer: Subbuffer<[u8]>,
+        device: Arc<Device>,
+    },
+}
+
 #[derive(Clone)]
 pub(crate) struct RenderItemRaw {
     pub(crate) pipeline: Arc<GraphicsPipeline>,
     pub(crate) pipeline_device: Arc<Device>,
     pub(crate) pipeline_render_pass: Arc<RenderPass>,
     pub(crate) geometry_device: Arc<Device>,
+    pub(crate) resources_device: Option<Arc<Device>>,
+    pub(crate) resources_pipeline_layout: Option<Arc<PipelineLayout>>,
+    pub(crate) descriptor_sets: Vec<Arc<DescriptorSet>>,
+    pub(crate) required_descriptor_set_count: usize,
     pub(crate) vertex_buffer: Subbuffer<[u8]>,
     pub(crate) index_buffer: Option<Subbuffer<[u32]>>,
     pub(crate) vertex_count: u32,
@@ -433,23 +629,138 @@ fn validate_geometry_inputs(vertex_count: usize, indices: Option<&[u32]>) -> VMN
     Ok(())
 }
 
-fn validate_raw_pipeline_layout(
-    has_descriptor_bindings: bool,
-    has_push_constants: bool,
-) -> VMNLResult<()> {
-    if has_descriptor_bindings {
+fn validate_resources_context(context: &Context, expected_device: &Arc<Device>) -> VMNLResult<()> {
+    if !Arc::ptr_eq(&context.inner.device, expected_device) {
         return Err(VMNLError::new(VMNLErrorKind::InvalidState(
-            "raw pipeline descriptors are not supported in checkpoint 1".into(),
-        )));
-    }
-
-    if has_push_constants {
-        return Err(VMNLError::new(VMNLErrorKind::InvalidState(
-            "raw pipeline push constants are not supported in checkpoint 1".into(),
+            "raw resources must be built from the same context as the raw pipeline".into(),
         )));
     }
 
     Ok(())
+}
+
+fn validate_supplied_resource_bindings(
+    set_layouts: &[Arc<DescriptorSetLayout>],
+    supplied_sets: &BTreeMap<u32, BTreeMap<u32, ResourceBinding>>,
+) -> VMNLResult<()> {
+    for (&set, supplied_bindings) in supplied_sets {
+        let set_layout = set_layouts.get(usize::try_from(set).map_err(|_| {
+            VMNLError::new(VMNLErrorKind::InvalidState(
+                "raw resources set index out of bounds".into(),
+            ))
+        })?);
+        let Some(set_layout) = set_layout else {
+            return Err(VMNLError::new(VMNLErrorKind::InvalidState(format!(
+                "raw resources set {set} is not declared by the pipeline"
+            ))));
+        };
+
+        for &binding in supplied_bindings.keys() {
+            if !set_layout.bindings().contains_key(&binding) {
+                return Err(VMNLError::new(VMNLErrorKind::InvalidState(format!(
+                    "raw resources set {set} binding {binding} is not declared by the pipeline"
+                ))));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn descriptor_writes_for_set(
+    context: &Context,
+    set: u32,
+    set_layout: &Arc<DescriptorSetLayout>,
+    supplied_bindings: &BTreeMap<u32, ResourceBinding>,
+) -> VMNLResult<Vec<WriteDescriptorSet>> {
+    let mut writes = Vec::with_capacity(supplied_bindings.len());
+
+    for (&binding, binding_layout) in set_layout.bindings() {
+        validate_raw_descriptor_binding(set, binding, binding_layout.descriptor_type)?;
+        if binding_layout.descriptor_count != 1 {
+            return Err(VMNLError::new(VMNLErrorKind::InvalidState(format!(
+                "raw resources set {set} binding {binding} descriptor arrays are not supported yet"
+            ))));
+        }
+
+        let resource = supplied_bindings.get(&binding).ok_or_else(|| {
+            VMNLError::new(VMNLErrorKind::InvalidState(format!(
+                "raw resources missing set {set} binding {binding}"
+            )))
+        })?;
+
+        match resource {
+            ResourceBinding::UniformBuffer { buffer, device } => {
+                if !Arc::ptr_eq(device, &context.inner.device) {
+                    return Err(VMNLError::new(VMNLErrorKind::InvalidState(format!(
+                        "raw resources set {set} binding {binding} must belong to this context"
+                    ))));
+                }
+                writes.push(WriteDescriptorSet::buffer(binding, buffer.clone()));
+            }
+        }
+    }
+
+    Ok(writes)
+}
+
+fn validate_raw_pipeline_layout(
+    layout_info: &PipelineDescriptorSetLayoutCreateInfo,
+) -> VMNLResult<()> {
+    if !layout_info.push_constant_ranges.is_empty() {
+        return Err(VMNLError::new(VMNLErrorKind::InvalidState(
+            "raw pipeline push constants are not supported yet".into(),
+        )));
+    }
+
+    for (set, set_layout) in layout_info.set_layouts.iter().enumerate() {
+        let set = u32::try_from(set)
+            .map_err(|_| VMNLError::new(VMNLErrorKind::VulkanValidationFailed))?;
+        validate_raw_descriptor_set_layout(set, set_layout)?;
+    }
+
+    Ok(())
+}
+
+fn validate_raw_descriptor_set_layout(
+    set: u32,
+    set_layout: &DescriptorSetLayoutCreateInfo,
+) -> VMNLResult<()> {
+    for (&binding, binding_layout) in &set_layout.bindings {
+        validate_raw_descriptor_binding(set, binding, binding_layout.descriptor_type)?;
+        if binding_layout.descriptor_count != 1 {
+            return Err(VMNLError::new(VMNLErrorKind::InvalidState(format!(
+                "raw pipeline set {set} binding {binding} descriptor arrays are not supported yet"
+            ))));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_raw_descriptor_binding(
+    set: u32,
+    binding: u32,
+    descriptor_type: DescriptorType,
+) -> VMNLResult<()> {
+    if descriptor_type != DescriptorType::UniformBuffer {
+        return Err(VMNLError::new(VMNLErrorKind::InvalidState(format!(
+            "raw pipeline set {set} binding {binding} only supports uniform buffers for now"
+        ))));
+    }
+
+    Ok(())
+}
+
+fn required_descriptor_set_count(layout: &PipelineLayout) -> usize {
+    required_descriptor_set_count_from_layouts(layout.set_layouts())
+}
+
+fn required_descriptor_set_count_from_layouts(set_layouts: &[Arc<DescriptorSetLayout>]) -> usize {
+    set_layouts
+        .iter()
+        .rposition(|set_layout| !set_layout.bindings().is_empty())
+        .map_or(0, |index| index + 1)
 }
 
 fn compile_shader(
@@ -502,6 +813,9 @@ fn color_blend_state(blend_mode: BlendMode) -> ColorBlendState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vulkano::descriptor_set::layout::DescriptorSetLayoutBinding;
+    use vulkano::pipeline::layout::{PipelineLayoutCreateFlags, PushConstantRange};
+    use vulkano::shader::ShaderStages;
 
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -538,16 +852,69 @@ mod tests {
     }
 
     #[test]
-    fn raw_pipeline_refuses_descriptor_layouts() {
-        let result = validate_raw_pipeline_layout(true, false);
+    fn raw_pipeline_accepts_uniform_descriptor_layouts() {
+        let layout_info = pipeline_layout_info(vec![descriptor_set_layout(
+            DescriptorType::UniformBuffer,
+            1,
+        )]);
 
-        assert!(result.is_err());
+        assert!(validate_raw_pipeline_layout(&layout_info).is_ok());
+    }
+
+    #[test]
+    fn raw_pipeline_refuses_unsupported_descriptor_layouts() {
+        let layout_info = pipeline_layout_info(vec![descriptor_set_layout(
+            DescriptorType::CombinedImageSampler,
+            1,
+        )]);
+
+        assert!(validate_raw_pipeline_layout(&layout_info).is_err());
+    }
+
+    #[test]
+    fn raw_pipeline_refuses_descriptor_arrays() {
+        let layout_info = pipeline_layout_info(vec![descriptor_set_layout(
+            DescriptorType::UniformBuffer,
+            2,
+        )]);
+
+        assert!(validate_raw_pipeline_layout(&layout_info).is_err());
     }
 
     #[test]
     fn raw_pipeline_refuses_push_constants() {
-        let result = validate_raw_pipeline_layout(false, true);
+        let layout_info = PipelineDescriptorSetLayoutCreateInfo {
+            flags: PipelineLayoutCreateFlags::empty(),
+            set_layouts: Vec::new(),
+            push_constant_ranges: vec![PushConstantRange {
+                stages: ShaderStages::VERTEX,
+                offset: 0,
+                size: 4,
+            }],
+        };
 
-        assert!(result.is_err());
+        assert!(validate_raw_pipeline_layout(&layout_info).is_err());
+    }
+
+    fn pipeline_layout_info(
+        set_layouts: Vec<DescriptorSetLayoutCreateInfo>,
+    ) -> PipelineDescriptorSetLayoutCreateInfo {
+        PipelineDescriptorSetLayoutCreateInfo {
+            flags: PipelineLayoutCreateFlags::empty(),
+            set_layouts,
+            push_constant_ranges: Vec::new(),
+        }
+    }
+
+    fn descriptor_set_layout(
+        descriptor_type: DescriptorType,
+        descriptor_count: u32,
+    ) -> DescriptorSetLayoutCreateInfo {
+        let mut layout = DescriptorSetLayoutCreateInfo::default();
+        let mut binding = DescriptorSetLayoutBinding::descriptor_type(descriptor_type);
+        binding.stages = ShaderStages::VERTEX;
+        binding.descriptor_count = descriptor_count;
+        layout.bindings.insert(0, binding);
+        layout
     }
 }

--- a/crates/vmnl_graphics/src/vmnl_instance/allocator.rs
+++ b/crates/vmnl_graphics/src/vmnl_instance/allocator.rs
@@ -12,6 +12,9 @@ use vulkano::{
     command_buffer::allocator::{
         StandardCommandBufferAllocator, StandardCommandBufferAllocatorCreateInfo,
     },
+    descriptor_set::allocator::{
+        StandardDescriptorSetAllocator, StandardDescriptorSetAllocatorCreateInfo,
+    },
     device::Device,
     memory::allocator::StandardMemoryAllocator,
 };
@@ -34,6 +37,18 @@ impl VMNLInstance {
             StandardCommandBufferAllocatorCreateInfo::default(),
         )
         .into()
+    }
+
+    /// Initialize the descriptor set allocator for shader resource bindings.
+    #[inline]
+    #[must_use = "descriptor set allocator is required for binding shader resources"]
+    pub(super) fn create_descriptor_set_allocator(
+        device: &Arc<Device>,
+    ) -> Arc<StandardDescriptorSetAllocator> {
+        Arc::new(StandardDescriptorSetAllocator::new(
+            device.clone(),
+            StandardDescriptorSetAllocatorCreateInfo::default(),
+        ))
     }
 
     /// Initialize the memory allocator for the Vulkan device.

--- a/crates/vmnl_graphics/src/vmnl_instance/mod.rs
+++ b/crates/vmnl_graphics/src/vmnl_instance/mod.rs
@@ -24,6 +24,7 @@ pub use context::Context;
 use std::sync::{Arc, Mutex};
 use vulkano::{
     command_buffer::allocator::StandardCommandBufferAllocator,
+    descriptor_set::allocator::StandardDescriptorSetAllocator,
     device::{physical::PhysicalDevice, Device, DeviceExtensions, Queue},
     instance::Instance,
     memory::allocator::StandardMemoryAllocator,
@@ -52,6 +53,8 @@ pub(crate) struct VMNLInstance {
     pub(crate) memory_allocator: Arc<StandardMemoryAllocator>,
     /// Command buffer allocator used to allocate and reuse command buffers.
     pub(crate) command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+    /// Descriptor set allocator used to bind raw shader resources.
+    pub(crate) descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     /// GLFW context used for window management and input handling.
     pub(crate) glfw: glfw::Glfw,
 }
@@ -100,6 +103,7 @@ impl VMNLInstance {
         )?;
         let memory_allocator = Self::create_memory_allocator(&device);
         let command_buffer_allocator = Self::create_command_buffer_allocator(&device);
+        let descriptor_set_allocator = Self::create_descriptor_set_allocator(&device);
 
         log::debug!("initialized VMNL instance");
         Ok(Self {
@@ -110,6 +114,7 @@ impl VMNLInstance {
             graphics_queue_family_index,
             memory_allocator,
             command_buffer_allocator,
+            descriptor_set_allocator,
             glfw,
         })
     }

--- a/crates/vmnl_graphics/src/window/api/render.rs
+++ b/crates/vmnl_graphics/src/window/api/render.rs
@@ -5,7 +5,9 @@
 
 use crate::d2::{Drawable2D, RenderItem2D};
 use crate::d3::{Camera, Drawable3D, RenderItem3D};
-use crate::raw::{Geometry as RawGeometry, Pipeline as RawPipeline, RenderItemRaw};
+use crate::raw::{
+    Geometry as RawGeometry, Pipeline as RawPipeline, RenderItemRaw, Resources as RawResources,
+};
 use crate::window::render::RenderPassCommand;
 use crate::window::Window;
 use crate::{VMNLError, VMNLErrorKind, VMNLResult};
@@ -187,6 +189,23 @@ impl<'w, 'g> FrameRenderer<'w, 'g> {
             items: geometries
                 .into_iter()
                 .map(|geometry| pipeline.render_item(geometry))
+                .collect(),
+        });
+        self
+    }
+
+    /// Add a raw render pass with descriptor resources to the pending frame.
+    #[must_use]
+    pub fn draw_raw_with<TVertex, const N: usize>(
+        mut self,
+        pipeline: &'g RawPipeline<TVertex>,
+        resources: &'g RawResources,
+        geometries: [&'g RawGeometry<TVertex>; N],
+    ) -> Self {
+        self.passes.push(FramePass::Raw {
+            items: geometries
+                .into_iter()
+                .map(|geometry| pipeline.render_item_with(geometry, resources))
                 .collect(),
         });
         self

--- a/crates/vmnl_graphics/src/window/render/command_buffer.rs
+++ b/crates/vmnl_graphics/src/window/render/command_buffer.rs
@@ -19,7 +19,7 @@ use vulkano::{
         RenderPassBeginInfo, SubpassBeginInfo, SubpassContents, SubpassEndInfo,
     },
     pipeline::Pipeline,
-    pipeline::{graphics::viewport::Viewport, GraphicsPipeline},
+    pipeline::{graphics::viewport::Viewport, GraphicsPipeline, PipelineBindPoint},
     render_pass::Framebuffer,
     swapchain::Swapchain,
 };
@@ -162,12 +162,57 @@ impl VMNLWindow {
                                         .into(),
                                 )));
                             }
+                            if let Some(resources_device) = &render_item.resources_device {
+                                if !Arc::ptr_eq(resources_device, &self.handle.vmnl_instance.device)
+                                {
+                                    return Err(VMNLError::new(VMNLErrorKind::InvalidState(
+                                        "raw resources must belong to this window context".into(),
+                                    )));
+                                }
+                            }
+                            if render_item.required_descriptor_set_count > 0 {
+                                let Some(resources_pipeline_layout) =
+                                    &render_item.resources_pipeline_layout
+                                else {
+                                    return Err(VMNLError::new(VMNLErrorKind::InvalidState(
+                                        "raw pipeline requires descriptor resources".into(),
+                                    )));
+                                };
+                                if render_item.descriptor_sets.len()
+                                    != render_item.required_descriptor_set_count
+                                {
+                                    return Err(VMNLError::new(VMNLErrorKind::InvalidState(
+                                        "raw pipeline descriptor resources are incomplete".into(),
+                                    )));
+                                }
+                                if !Arc::ptr_eq(
+                                    resources_pipeline_layout,
+                                    render_item.pipeline.layout(),
+                                ) {
+                                    return Err(VMNLError::new(VMNLErrorKind::InvalidState(
+                                        "raw resources must be built for this raw pipeline".into(),
+                                    )));
+                                }
+                            }
 
                             builder
                                 .bind_pipeline_graphics(render_item.pipeline.clone())
                                 .map_err(|_| {
                                     VMNLError::new(VMNLErrorKind::VulkanPipelineCreationFailed)
-                                })?
+                                })?;
+                            if !render_item.descriptor_sets.is_empty() {
+                                builder
+                                    .bind_descriptor_sets(
+                                        PipelineBindPoint::Graphics,
+                                        render_item.pipeline.layout().clone(),
+                                        0,
+                                        render_item.descriptor_sets.clone(),
+                                    )
+                                    .map_err(|_| {
+                                        VMNLError::new(VMNLErrorKind::VulkanValidationFailed)
+                                    })?;
+                            }
+                            builder
                                 .bind_vertex_buffers(0, render_item.vertex_buffer.clone())
                                 .map_err(|_| {
                                     VMNLError::new(VMNLErrorKind::VulkanVertexBufferCreationFailed)

--- a/examples/raw_uniform/Cargo.toml
+++ b/examples/raw_uniform/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "raw_uniform"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+vmnl = { path = "../../crates/vmnl" }

--- a/examples/raw_uniform/src/main.rs
+++ b/examples/raw_uniform/src/main.rs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Hugo Duda
+// SPDX-License-Identifier: MIT
+
+use vmnl::{raw, Context, PresentMode, VMNLResult, Window};
+
+const VERT: &str = r#"
+#version 460
+
+layout(location = 0) in vec2 position;
+layout(location = 1) in vec3 color;
+
+layout(set = 0, binding = 0) uniform RawUniform {
+    vec4 tint;
+    vec4 offset;
+} uniforms;
+
+layout(location = 0) out vec3 out_color;
+
+void main() {
+    gl_Position = vec4(position + uniforms.offset.xy, 0.0, 1.0);
+    out_color = color * uniforms.tint.rgb;
+}
+"#;
+
+const FRAG: &str = r#"
+#version 460
+
+layout(location = 0) in vec3 in_color;
+layout(location = 0) out vec4 out_color;
+
+layout(set = 0, binding = 0) uniform RawUniform {
+    vec4 tint;
+    vec4 offset;
+} uniforms;
+
+void main() {
+    out_color = vec4(in_color, uniforms.tint.a);
+}
+"#;
+
+#[repr(C)]
+#[derive(Clone, Copy, raw::Vertex, raw::Pod, raw::Zeroable)]
+struct RawVertex {
+    #[format(R32G32_SFLOAT)]
+    position: [f32; 2],
+    #[format(R32G32B32_SFLOAT)]
+    color: [f32; 3],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, raw::Pod, raw::Zeroable)]
+struct RawUniform {
+    tint: [f32; 4],
+    offset: [f32; 4],
+}
+
+fn main() -> VMNLResult<()> {
+    let context = Context::new()?;
+    let mut window = Window::builder()
+        .title("VMNL raw uniform")
+        .size(900, 600)
+        .set_clear_color([8, 10, 14, 255])
+        .present_mode(PresentMode::Auto)
+        .build(&context)?;
+
+    let pipeline = raw::Pipeline::<RawVertex>::builder()
+        .vertex_shader(raw::ShaderSource::Src(VERT.into()))
+        .fragment_shader(raw::ShaderSource::Src(FRAG.into()))
+        .topology(raw::PrimitiveTopology::TriangleList)
+        .blend_mode(raw::BlendMode::Alpha)
+        .build(&window)?;
+
+    let uniform = raw::Uniform::builder(RawUniform {
+        tint: [1.0, 0.85, 0.45, 0.95],
+        offset: [0.15, 0.05, 0.0, 0.0],
+    })
+    .build(&context)?;
+    let resources = raw::Resources::builder(&pipeline)
+        .uniform(0, 0, &uniform)
+        .build(&context)?;
+
+    let geometry = raw::Geometry::builder([
+        RawVertex {
+            position: [-0.65, -0.55],
+            color: [1.0, 0.0, 0.0],
+        },
+        RawVertex {
+            position: [0.55, -0.45],
+            color: [0.0, 1.0, 0.0],
+        },
+        RawVertex {
+            position: [-0.05, 0.65],
+            color: [0.0, 0.25, 1.0],
+        },
+    ])
+    .build(&context)?;
+
+    while window.is_open() {
+        for _ in window.poll_events() {}
+        window
+            .render()
+            .draw_raw_with(&pipeline, &resources, [&geometry])
+            .submit()?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Context

Raw pipelines supported custom shaders and typed geometry, but shaders requiring descriptor resources were still unusable because descriptor layouts were rejected. This PR adds the first raw shader resource path so custom shaders can bind typed uniform buffers while keeping textures, materials, push constants, descriptor arrays, storage buffers, and 3D out of scope.

## Changes

- Adds `raw::Uniform<T>` and `raw::Resources` builders for typed uniform buffer descriptors.
- Adds raw descriptor set allocation to the VMNL Vulkan instance.
- Allows raw pipelines to declare single uniform buffer descriptors and keeps push constants plus unsupported descriptor types explicitly rejected.
- Adds `FrameRenderer::draw_raw_with` to bind raw resources before raw geometry draws.
- Preserves existing `draw_raw` behavior for pipelines without descriptors.
- Adds the `raw_uniform` workspace example demonstrating a raw shader using `layout(set = 0, binding = 0) uniform`.
- Updates raw unit tests for uniform descriptor acceptance and unsupported descriptor rejection.
- Documentation files were not updated in this commit.

## Validation

- Operator verified `raw_uniform` visually.
- Operator verified the other visual examples still work.